### PR TITLE
Base mixin on BlocBase - allow use it on Cubit

### DIFF
--- a/example/lib/page_one/bloc/page_one_bloc.dart
+++ b/example/lib/page_one/bloc/page_one_bloc.dart
@@ -8,7 +8,7 @@ part 'page_one_event.dart';
 part 'page_one_state.dart';
 
 class PageOneBloc extends Bloc<PageOneEvent, PageOneState>
-    with SideEffectBlocMixin<PageOneEvent, PageOneState, PageOneCommand> {
+    with SideEffectBlocMixin<PageOneState, PageOneCommand> {
   PageOneBloc() : super(const PageOneState.initial()) {
     on<NextClick>(
       (event, emit) {

--- a/example/lib/page_one/page_one.dart
+++ b/example/lib/page_one/page_one.dart
@@ -34,15 +34,11 @@ class _PageOneState extends State<PageOne> {
               children: [
                 ElevatedButton(
                   child: const Text("To second page"),
-                  onPressed: () => context
-                      .read<PageOneBloc>()
-                      .add(const PageOneEvent.nextClick()),
+                  onPressed: () => context.read<PageOneBloc>().add(const PageOneEvent.nextClick()),
                 ),
                 ElevatedButton(
                   child: const Text("Show scankbar"),
-                  onPressed: () => context
-                      .read<PageOneBloc>()
-                      .add(const PageOneEvent.openSnackbarClick()),
+                  onPressed: () => context.read<PageOneBloc>().add(const PageOneEvent.openSnackbarClick()),
                 ),
               ],
             ),

--- a/example/lib/page_two/cubit/page_two_cubit.dart
+++ b/example/lib/page_two/cubit/page_two_cubit.dart
@@ -1,0 +1,17 @@
+import 'package:bloc/bloc.dart';
+import 'package:meta/meta.dart';
+import 'package:side_effect_bloc/side_effect_bloc.dart';
+
+part 'page_two_event.dart';
+part 'page_two_state.dart';
+
+class PageTwoCubit extends Cubit<PageTwoState> with SideEffectBlocMixin<PageTwoState, PageTwoShowDialogEvent> {
+  PageTwoCubit() : super(PageTwoInitial());
+
+  Future<void> processData() async {
+    //processing heavy task
+    await Future.delayed(const Duration(milliseconds: 500));
+
+    produceSideEffect(PageTwoShowDialogEvent(label: 'Done'));
+  }
+}

--- a/example/lib/page_two/cubit/page_two_event.dart
+++ b/example/lib/page_two/cubit/page_two_event.dart
@@ -1,0 +1,9 @@
+part of 'page_two_cubit.dart';
+
+class PageTwoShowDialogEvent {
+  final String label;
+
+  PageTwoShowDialogEvent({
+    required this.label,
+  });
+}

--- a/example/lib/page_two/cubit/page_two_state.dart
+++ b/example/lib/page_two/cubit/page_two_state.dart
@@ -1,0 +1,6 @@
+part of 'page_two_cubit.dart';
+
+@immutable
+abstract class PageTwoState {}
+
+class PageTwoInitial extends PageTwoState {}

--- a/example/lib/page_two/page_two.dart
+++ b/example/lib/page_two/page_two.dart
@@ -1,4 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:side_effect_bloc/side_effect_bloc.dart';
+
+import 'cubit/page_two_cubit.dart';
 
 class PageTwo extends StatefulWidget {
   const PageTwo({Key? key}) : super(key: key);
@@ -10,9 +14,29 @@ class PageTwo extends StatefulWidget {
 class _PageTwoState extends State<PageTwo> {
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text('Page Two'),
+    return BlocProvider(
+      create: (context) => PageTwoCubit(),
+      child: Scaffold(
+        appBar: AppBar(
+          title: const Text('Page Two'),
+        ),
+        body: Builder(
+          builder: (context) => BlocSideEffectListener<PageTwoCubit, PageTwoShowDialogEvent>(
+            listener: (context, event) {
+              showDialog(
+                context: context,
+                builder: (context) => AlertDialog(
+                  title: Text(event.label),
+                  actions: [TextButton(onPressed: () => Navigator.of(context).pop(), child: const Text('OK'))],
+                ),
+              );
+            },
+            child: Center(
+              child: ElevatedButton(
+                  onPressed: () => context.read<PageTwoCubit>().processData(), child: const Text('Process data')),
+            ),
+          ),
+        ),
       ),
     );
   }

--- a/example/windows/flutter/generated_plugins.cmake
+++ b/example/windows/flutter/generated_plugins.cmake
@@ -5,6 +5,9 @@
 list(APPEND FLUTTER_PLUGIN_LIST
 )
 
+list(APPEND FLUTTER_FFI_PLUGIN_LIST
+)
+
 set(PLUGIN_BUNDLED_LIBRARIES)
 
 foreach(plugin ${FLUTTER_PLUGIN_LIST})
@@ -13,3 +16,8 @@ foreach(plugin ${FLUTTER_PLUGIN_LIST})
   list(APPEND PLUGIN_BUNDLED_LIBRARIES $<TARGET_FILE:${plugin}_plugin>)
   list(APPEND PLUGIN_BUNDLED_LIBRARIES ${${plugin}_bundled_libraries})
 endforeach(plugin)
+
+foreach(ffi_plugin ${FLUTTER_FFI_PLUGIN_LIST})
+  add_subdirectory(flutter/ephemeral/.plugin_symlinks/${ffi_plugin}/windows plugins/${ffi_plugin})
+  list(APPEND PLUGIN_BUNDLED_LIBRARIES ${${ffi_plugin}_bundled_libraries})
+endforeach(ffi_plugin)

--- a/lib/src/side_effect_bloc.dart
+++ b/lib/src/side_effect_bloc.dart
@@ -7,7 +7,16 @@ import 'package:side_effect_bloc/src/side_effect_bloc_mixin.dart';
 /// Abstract class which extend base bloc with `Stream` of `Side effects`
 /// {@endtemplate}
 abstract class SideEffectBloc<EVENT, STATE, COMMAND> extends Bloc<EVENT, STATE>
-    with SideEffectBlocMixin<EVENT, STATE, COMMAND> {
+    with SideEffectBlocMixin<STATE, COMMAND> {
   /// {@macro side_effect_bloc}
   SideEffectBloc(STATE initialState) : super(initialState);
+}
+
+/// {@template side_effect_bloc}
+/// Abstract class which extend base cubit with `Stream` of `Side effects`
+/// {@endtempla
+abstract class SideEffectCubit<STATE, EFFECT> extends Cubit<STATE>
+    with SideEffectBlocMixin<STATE, EFFECT> {
+  /// {@macro side_effect_bloc}
+  SideEffectCubit(STATE initialState) : super(initialState);
 }

--- a/lib/src/side_effect_bloc_mixin.dart
+++ b/lib/src/side_effect_bloc_mixin.dart
@@ -9,7 +9,7 @@ import 'package:side_effect_bloc/src/side_effect_provider.dart';
 /// {@template side_effect_bloc_mixin}
 /// Mixin to enrich the existing bloc  with `Stream` of `Side effects`
 /// {@endtemplate}
-mixin SideEffectBlocMixin<EVENT, STATE, SIDE_EFFECT> on Bloc<EVENT, STATE>
+mixin SideEffectBlocMixin<STATE, SIDE_EFFECT> on BlocBase<STATE>
     implements SideEffectProvider<SIDE_EFFECT> {
   final StreamController<SIDE_EFFECT> _sideEffectController =
       StreamController.broadcast();


### PR DESCRIPTION
When mixin "on" clausule is changed to be based on BlocBase<STATE>, it is possible to use it with Cubit as well. Moreover there is no need to be based on Bloc as "EVENT" type parameter is not even used. 

- I've added example usage as well. 